### PR TITLE
setFibreField.C: enforce OpenFOAM code style and reduce code repetition

### DIFF
--- a/applications/utilities/setFibreField/setFibreField.C
+++ b/applications/utilities/setFibreField/setFibreField.C
@@ -1,4 +1,4 @@
-/*--------A---A------A---------------------------------------------------------*\
+/*--------------------------------------------------------------------------*\
 License
     This file is part of solids4foam.
 
@@ -33,7 +33,80 @@ Author
 #include "transform.H"
 #include "unitConversion.H"
 
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+// * * * * * * * * * * * * * Help Functions  * * * * * * * * * * * * * * * * //
+
+// Land et al. (2015) approach
+// The procedure is ported from the Matlab xyz_to_fiber.m script available
+// in the mechbench repository shared on bitbucket
+void xyzToFibre
+(
+    const scalar x,
+    const scalar y,
+    const scalar z,
+    const scalar rl,
+    const scalar rs,
+    const scalar fibreAngle,
+    scalar& uu,
+    scalar& vv,
+    scalar& q,
+    vector& f
+)
+{
+    // vv
+    vv = Foam::atan2(-y, -x);
+
+    // q
+    if (mag(Foam::cos(vv)) > 1e-6)
+    {
+        q = x/Foam::cos(vv);
+    }
+    else
+    {
+        q = y/Foam::sin(vv);
+    }
+
+    // u
+    uu = Foam::acos(z/rl);
+
+    if (uu > 0)
+    {
+        uu = -uu;
+    }
+
+    const vector derivDir
+    (
+        Foam::sin(fibreAngle), Foam::cos(fibreAngle), 0.0
+    );
+
+    vector Mcol0
+    (
+        rs*std::cos(uu)*std::cos(vv),
+        rs*std::cos(uu)*std::sin(vv),
+        -rl*std::sin(uu)
+    );
+    Mcol0 /= mag(Mcol0);
+
+    vector Mcol1
+    (
+        -rs*std::sin(uu)*std::sin(vv),
+        rs*std::sin(uu)*std::cos(vv),
+        0
+    );
+    Mcol1 /= mag(Mcol1);
+
+    const tensor M
+    (
+        Mcol0.x(), Mcol1.x(), 0,
+        Mcol0.y(), Mcol1.y(), 0,
+        Mcol0.z(), Mcol1.z(), 0
+    );
+
+    f = M & derivDir;
+    f /= mag(f);
+}
+
+
+// * * * * * * * * * * * * * Main Program  * * * * * * * * * * * * * * * * * //
 
 int main(int argc, char *argv[])
 {
@@ -41,13 +114,10 @@ int main(int argc, char *argv[])
     #include "setRootCase.H"
     #include "createTime.H"
     #include "createNamedMesh.H"
-    #include "vector.H"
-    #include "tensor.H"
-    #include "cmath"
 
     // Read the transmural distance field
     Info<< "Reading t" << endl;
-    
+
     volScalarField t
     (
         IOobject
@@ -62,55 +132,46 @@ int main(int argc, char *argv[])
     );
 
     Info<< "Solving the diffusion equation for t" << endl;
-    
+
     fvScalarMatrix tEqn(fvm::laplacian(t));
- 
+
     tEqn.solve();
     Info<< "Writing t" << endl;
-  
+
     t.write();
 
-    //using alpha radians as described in Arostica
-    const scalar fibre_Angle_Endo = 90.0;
+    // Fibre angle at the inner surface
+    const scalar fibreAngleEndo = 90.0;
 
-    // alpha at the epicardium: SHOULD BE INPUT PARAMETER
-    const scalar fibre_Angle_Epi = -90.0;
+    // Fibre angle at the puter surface
+    const scalar fibreAngleEpi = -90.0;
 
     const scalar pi = Foam::constant::mathematical::pi;
 
     const volScalarField alphaRadians
     (
         "alphaRadians",
-        (fibre_Angle_Endo + (fibre_Angle_Epi - fibre_Angle_Endo)*t) * pi/180
+        (fibreAngleEndo + (fibreAngleEpi - fibreAngleEndo)*t)*pi/180.0
     );
-    
+
     Info<< "Writing alphaRadians" << endl;
     alphaRadians.write();
 
-    
 
+    // Creating rs and rs to define other stuff
 
-    /*
-     *
-     *TRYING A NEW APPROACH BY EXPLICITLY FOLLOWING THE NEWEST PAPER.
-     *
-     *
-     */
-
-    //creating rs and rs to define other stuff.
-
-    //Constants as defined from Eq's (10-11)
+    // Constants as defined from Eq's (10-11)
     // with r_long_endo = 9x10^-2
     //from Eq (16) of the paper we get rs and rl
     const volScalarField rs
     (
         "rs",
-	7 + 3*t
+        7 + 3*t
     );
     Info<< "Writing rs" << endl;
     rs.write();
 
-    
+
     const volScalarField rl
     (
         "rl",
@@ -119,232 +180,131 @@ int main(int argc, char *argv[])
     Info<< "Writing rl" << endl;
     rl.write();
 
-    
-    //initialising uu from the paper
-    volScalarField uu
-      (
-       IOobject
-       (
-        "uu",                    // Name of the field
-        runTime.timeName(),     // Time directory (e.g., "0", "1", etc.)
-        mesh,                   // Mesh to associate the field with
-        IOobject::NO_READ,      // Do not read from disk (no existing file)
-        IOobject::AUTO_WRITE    // Write the field automatically to disk
-	),
-       mesh,
-       dimensionedScalar("uu", dimless, 0.0) // Mesh to define the field on
-       );
 
-    //Initialising vv from the paper
-    volScalarField vv
-      (
-       IOobject
-       (
-        "vv",                    // Name of the field                                                                                                        
-        runTime.timeName(),     // Time directory (e.g., "0", "1", etc.)                                                                                    
-        mesh,                   // Mesh to associate the field with                                                                                         
-        IOobject::NO_READ,      // Do not read from disk (no existing file)                                                                                 
-        IOobject::AUTO_WRITE    // Write the field automatically to disk                                                                                    
+    // Initialising uu
+    volScalarField uu
+    (
+        IOobject
+        (
+            "uu",                    // Name of the field
+            runTime.timeName(),     // Time directory (e.g., "0", "1", etc.)
+            mesh,                   // Mesh to associate the field with
+            IOobject::NO_READ,      // Do not read from disk (no existing file)
+            IOobject::AUTO_WRITE    // Write the field automatically to disk
         ),
-       mesh,
-       dimensionedScalar("vv", dimless, 0.0)                                                                                             
-       );
+        mesh,
+        dimensionedScalar("uu", dimless, 0.0) // Mesh to define the field on
+    );
+
+    // Initialising vv
+    volScalarField vv
+    (
+        IOobject
+        (
+            "vv",                    // Name of the field
+            runTime.timeName(),     // Time directory (e.g., "0", "1", etc.)
+            mesh,                   // Mesh to associate the field with
+            IOobject::NO_READ,      // Do not read from disk (no existing file)
+            IOobject::AUTO_WRITE    // Write the field automatically to disk
+        ),
+        mesh,
+        dimensionedScalar("vv", dimless, 0.0)
+    );
 
     volScalarField q
-      (
-       IOobject
-       (
-	"q",
+    (
+        IOobject
+        (
+            "q",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        dimensionedScalar("q", dimless, 0.0)
+    );
 
-	runTime.timeName(),
+    // Initialising the fibres
+    volVectorField f0
+    (
+        IOobject
+        (
+            "f0",        // Field name
+            mesh.time().timeName(), // Time directory (still required but not used)
+            mesh,             // Mesh reference
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh,
+        vector::zero
+    );
 
-	mesh,
+    // Take references for efficiency and brevity
+    const volVectorField& C = mesh.C();
+    const vectorField& CI = C;
 
-	IOobject::NO_READ,
+    // Looping through an updating the mu and theta values
+    forAll(CI, cellI)
+    {
+        xyzToFibre
+        (
+            CI[cellI].x(),
+            CI[cellI].y(),
+            CI[cellI].z(),
+            rl[cellI],
+            rs[cellI],
+            alphaRadians[cellI],
+            uu[cellI],
+            vv[cellI],
+            q[cellI],
+            f0[cellI]
+        );
+    }
 
-	IOobject::AUTO_WRITE
+    // Loop over boundary patches
+    forAll(C.boundaryField(), patchI)
+    {
+        // Loop over faces in patch
+        const vectorField& CP = C.boundaryField()[patchI];
+        const scalarField& rlP = rl.boundaryField()[patchI];
+        const scalarField& rsP = rs.boundaryField()[patchI];
+        const scalarField& alphaRadiansP = alphaRadians.boundaryField()[patchI];
+        scalarField& uuP = uu.boundaryFieldRef()[patchI];
+        scalarField& vvP = uu.boundaryFieldRef()[patchI];
+        scalarField& qP = uu.boundaryFieldRef()[patchI];
+        vectorField& f0P = f0.boundaryFieldRef()[patchI];
+        forAll(CP, faceI) 
+        {
+            xyzToFibre
+            (
+                CP[faceI].x(),
+                CP[faceI].y(),
+                CP[faceI].z(),
+                rlP[faceI],
+                rsP[faceI],
+                alphaRadiansP[faceI],
+                uuP[faceI],
+                vvP[faceI],
+                qP[faceI],
+                f0P[faceI]
+            );
+        }
+    }
 
-	),
-       mesh,
-       dimensionedScalar("q", dimless, 0.0)
-       );
-
-    //looping through an updating the mu and thetha values based procedure described in paper
-    forAll(mesh.C(), cellI)
-      {
-        
-	scalar x =  mesh.C()[cellI].x();
-	scalar y = mesh.C()[cellI].y();
-	scalar z = mesh.C()[cellI].z();
-
-	vv[cellI] = Foam::atan2(-y, -x);
-	
-	if(std::abs(Foam::cos(vv[cellI])) > 1e-6)
-	  {
-	    q[cellI] = x / Foam::cos(vv[cellI]);
-	  }
-	
-	else
-	  {
-	    q[cellI] = y / Foam::sin(vv[cellI]);
-	  }
-
-	uu[cellI] = Foam::acos(z / rl[cellI]);
-
-	if(uu[cellI] > 0)
-	  {
-	    uu[cellI] = -uu[cellI];
-	  }
-      }
-
-    forAll(mesh.C().boundaryField(), patchI)  // Loop over boundary patches
-      {
-	forAll(mesh.C().boundaryField()[patchI], faceI)  // Loop over faces in patch
-	  {
-	    scalar x =  mesh.C().boundaryField()[patchI][faceI].x();
-	    scalar y = mesh.C().boundaryField()[patchI][faceI].y();
-	    scalar z = mesh.C().boundaryField()[patchI][faceI].z();
-
-	    vv.boundaryFieldRef()[patchI][faceI] = Foam::atan2(-y, -x);
-	    
-	    if (std::abs(Foam::cos(vv.boundaryFieldRef()[patchI][faceI])) > 1e-6)
-	      {
-		q.boundaryFieldRef()[patchI][faceI] = x / Foam::cos(vv.boundaryField()[patchI][faceI]);
-	      }
-	    else
-	      {
-		q.boundaryFieldRef()[patchI][faceI] = y / Foam::sin(vv.boundaryField()[patchI][faceI]);
-	      }
-
-
-	    uu.boundaryFieldRef()[patchI][faceI] = Foam::acos(z / rl.boundaryField()[patchI][faceI]);
-
-	    if(uu.boundaryFieldRef()[patchI][faceI] > 0)
-	      {
-		uu.boundaryFieldRef()[patchI][faceI] = -uu.boundaryField()[patchI][faceI];
-	      }
-	  }
-      }
-
-    
     Info<< "Writing uu" << endl;
     uu.write();
     Info<< "Writing vv" << endl;
     vv.write();
     Info<< "Writing q" << endl;
     q.write();
-    
-    
-    //Initialising the fibres
-    volVectorField f1
-      (
-       IOobject
-       (
-        "f1",        // Field name
-        mesh.time().timeName(), // Time directory (still required but not used)
-        mesh,             // Mesh reference
-        IOobject::NO_READ,
-        IOobject::NO_WRITE
-	),
-       mesh,
-       vector::zero
-       );
-    
-    //Calculating the fibres based on Eq (15)
-    forAll(mesh.C(), cellI)
-    {
-      scalar u = uu[cellI];
-      scalar v = vv[cellI];
-      scalar fibre_angle = alphaRadians[cellI];
-      scalar short_r = rs[cellI];
-      scalar long_r = rl[cellI];
 
-
-      vector deriv_dir(Foam::sin(fibre_angle), Foam::cos(fibre_angle), 0.0);
-
-
-      vector Mcol0(
-		   short_r * std::cos(u) * std::cos(v),
-		   short_r * std::cos(u) * std::sin(v),
-		   -long_r * std::sin(u)
-		   );
-      vector Mcol1(
-		   -short_r * std::sin(u) * std::sin(v),
-		   short_r * std::sin(u) * std::cos(v),
-		   0
-		   );
-
-      Mcol0 /= mag(Mcol0);
-      Mcol1 /= mag(Mcol1);
-
-      tensor M(
-	       Mcol0.x(), Mcol1.x(), 0,
-	       Mcol0.y(), Mcol1.y(), 0,
-	       Mcol0.z(), Mcol1.z(), 0
-	       );
-
-      vector fVal = M & deriv_dir;
-
-      f1[cellI] = fVal;
-    }
-
-    // doing the same procedure for the boundaries
-    forAll(f1.boundaryField(), patchI)
-      {
-	forAll(f1.boundaryField()[patchI], faceI)
-	  {
-	    scalar u = uu.boundaryField()[patchI][faceI];
-	    scalar v = vv.boundaryField()[patchI][faceI];
-	    scalar fibre_angle = alphaRadians.boundaryField()[patchI][faceI];
-	    scalar short_r = rs.boundaryField()[patchI][faceI];
-	    scalar long_r = rl.boundaryField()[patchI][faceI];
-	    
-
-
-	    vector deriv_dir(Foam::sin(fibre_angle), Foam::cos(fibre_angle), 0.0);
-
-
-	    vector Mcol0(
-			 short_r * std::cos(u) * std::cos(v),
-			 short_r * std::cos(u) * std::sin(v),
-			 -long_r * std::sin(u)
-			 );
-	    vector Mcol1(
-			 -short_r * std::sin(u) * std::sin(v),
-			 short_r * std::sin(u) * std::cos(v),
-			 0
-			 );
-
-	    Mcol0 /= mag(Mcol0);
-	    Mcol1 /= mag(Mcol1);
-
-	    tensor M(
-		     Mcol0.x(), Mcol1.x(), 0,
-		     Mcol0.y(), Mcol1.y(), 0,
-		     Mcol0.z(), Mcol1.z(), 0
-		     );
-
-	    vector fVal = M & deriv_dir;
-
-	    f1.boundaryFieldRef()[patchI][faceI] = fVal;
-	    
-	    
-	  }
-	  }
-
-    // Optionally, write out the result to a file
-    f1 /= mag(f1);
-    Info<< "Writing f1" << endl;
-    f1.write();
-
-    
-
-
-    volVectorField f0("f0", f1);
+    // Write f0
+    Info<< "Writing " << f0.name() << nl << endl;
     f0.write();
 
-    
-    
+    Info<< "Done" << nl << endl;
+
     return 0;
 }
 


### PR DESCRIPTION
Hi @Aaron-Mullen-Hales,

Your code looks good; it seems to be consistent with `xyz_to_fiber.m`.

Here, I made changes to enforce the OpenFOAM coding style (https://openfoam.org/dev/coding-style-guide/); it is normally possible to set up your text editor to help with following the style guide. Take note of the particular changes and try to follow them for future code.

Also, I have added a function to avoid code duplication/repetition.

Let me know if you have any questions. Then please merge this.

Thanks
